### PR TITLE
doc(CI) : Cleaner CI

### DIFF
--- a/duck.sql
+++ b/duck.sql
@@ -1,7 +1,6 @@
 -- Load acronyms data
-create
-or replace table acronyms (
-    id_acronym VARCHAR NOT NULL, CHECK (id_acronym = UPPER(id_acronym)),
+create or replace table acronyms (
+    id_acronym VARCHAR NOT NULL CHECK (id_acronym = UPPER(id_acronym)),
     description  VARCHAR UNIQUE
 );
 
@@ -16,7 +15,11 @@ from
     })
     ) t;
 
-from acronyms;
+-- Get a preveiw
+from acronyms limit 5;
+
+------------------------------------------------
+-- Preserve order of rows
 
 -- Prepare test environment
 CREATE SEQUENCE seq_original START 1;
@@ -24,24 +27,34 @@ CREATE SEQUENCE seq_sorted START 1;
 
 create or replace temp table orig_table as
     select nextval('seq_original') as index,
-    id_acronym, description from acronyms;
+            id_acronym,
+            description
+    from acronyms;
 
 create or replace temp table sorted_table as
     select nextval('seq_sorted') as index,
-    id_acronym, description
-    from (select id_acronym, description from acronyms order by id_acronym, description);
+            id_acronym,
+            description
+    from (select id_acronym,
+                description
+            from acronyms
+            -- order by acronym and description
+            order by id_acronym, description);
 
 -- Check the resulting tables
-from orig_table;
-from sorted_table;
+from orig_table limit 5;
+from sorted_table limit 5;
 
 -- Create the table that compares the sorted and original tables columns
-create or replace temp table test_sorted(orig_id_acronym varchar, orig_description varchar,
+create or replace temp table test_sorted(
+                                    orig_id_acronym varchar,
+                                    orig_description varchar,
                                     orig_index integer,
                                     sorted_index integer
                                     -- the magic part XD
                                     check(orig_index = sorted_index)
                                     );
+
 -- Populate the comparison table
 insert into test_sorted
 select


### PR DESCRIPTION
# :grey_question: A propos

En exploitant les logs de la CI, je me suis rendu compte que c'était super verbeux. Cette PR fixe ça avec un peu de formatgae sql pour rendre la lecture plus aisée pour les nouveaux arrivants


C beucoup plus facile à lire : 
![image](https://github.com/opt-nc/odata-acronyms/assets/5235127/c20c2102-54cb-41b6-8481-2dfd4edbfe38)
